### PR TITLE
Explicitly force Archey to use Python 3

### DIFF
--- a/archey
+++ b/archey
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Archey [version 0.3.0]
 #

--- a/archey.new
+++ b/archey.new
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Archey [version 0.3.0]
 #


### PR DESCRIPTION
Some users change ArchLinux's behavior to default to Python 2 for development reasons. However, archey fails for Python 2.

I've simply changed the Python line to use explicitly use Python 3.
