### PR TITLE
RAM fixed

### DIFF
--- a/archey
+++ b/archey
@@ -206,7 +206,7 @@ class CPU:
 
 class RAM:
 	def __init__(self):
-		raminfo = Popen(['free', '-m'], stdout=PIPE).communicate()[0].decode('Utf-8').split('\n')
+		raminfo = Popen(['free', '-mw'], stdout=PIPE, env={'LANG': 'C'}).communicate()[0].decode('Utf-8').split('\n')
 		ram = ''.join(filter(re.compile('M').search, raminfo)).split()
 		used = int(ram[2]) - int(ram[5]) - int(ram[6])
 		usedpercent = ((float(used) / float(ram[1])) * 100)


### PR DESCRIPTION
Because of an update of the free-command, there was added a new feature to use system language to output memory usage. By using the LANG=C environment variable, this is no more a problem. Also something in the columns has changed, so the -w option is added to show the "wide column style" again. If not, the used memory is calculated wrong.
