### PR TITLE
df command syntax fix

### DIFF
--- a/archey
+++ b/archey
@@ -225,7 +225,7 @@ class RAM:
 			
 class Disk:
     def __init__(self):
-        p1 = Popen(['df', '-Tlh', '--total', '-t', 'ext4', '-t', 'ext3', '-t', 'ext2', '-t', 'reiserfs', '-t', 'jfs', '-t', 'ntfs', '-t', 'fat32', '-t', 'btrfs', '-t', 'fuseblk', '-t', 'xfs'], stdout=PIPE).communicate()[0].decode("Utf-8")
+        p1 = Popen(['df', '-Tlh', '-B', 'GB', '--total', '-t', 'ext4', '-t', 'ext3', '-t', 'ext2', '-t', 'reiserfs', '-t', 'jfs', '-t', 'ntfs', '-t', 'fat32', '-t', 'btrfs', '-t', 'fuseblk', '-t', 'xfs'], stdout=PIPE).communicate()[0].decode("Utf-8")
         total = p1.splitlines()[-1]
         used = total.split()[3]
         size = total.split()[2]


### PR DESCRIPTION
I updated the df command since it were showing wrong free/used space in my ubuntu 14.04 box. The problem is that the command reported at line 228 displays my free space with 'G' as gigabytes, instead of 'GB'. I added an option -B GB to let this display the correct way.

I don't know if this is a locale issue or else...i just fixed it this way.
