### PR TITLE
fix negative used RAM

### DIFF
--- a/archey
+++ b/archey
@@ -212,14 +212,15 @@ class RAM:
 	def __init__(self):
 		raminfo = Popen(['free', '-m'], stdout=PIPE).communicate()[0].decode('Utf-8').split('\n')
 		ram = ''.join(filter(re.compile('M').search, raminfo)).split()
-		used = int(ram[2]) - int(ram[5]) - int(ram[6])
-		usedpercent = ((float(used) / float(ram[1])) * 100)
+		used = int(ram[2])
+		total = ram[1]
+		usedpercent = ((float(used) / float(total)) * 100)
 		if usedpercent <= 33:
-			ramdisplay = '%s%s MB %s/ %s MB' % (colorDict['Sensors'][1], used, colorDict['Clear'][0], ram[1])
+			ramdisplay = '%s%s MB %s/ %s MB' % (colorDict['Sensors'][1], used, colorDict['Clear'][0], total)
 		if usedpercent > 33 and usedpercent < 67:
-			ramdisplay = '%s%s MB %s/ %s MB' % (colorDict['Sensors'][2], used, colorDict['Clear'][0], ram[1])
+			ramdisplay = '%s%s MB %s/ %s MB' % (colorDict['Sensors'][2], used, colorDict['Clear'][0], total)
 		if usedpercent >= 67:
-			ramdisplay = '%s%s MB %s/ %s MB' % (colorDict['Sensors'][0], used, colorDict['Clear'][0], ram[1])
+			ramdisplay = '%s%s MB %s/ %s MB' % (colorDict['Sensors'][0], used, colorDict['Clear'][0], total)
 		self.key = 'RAM'
 		self.value = ramdisplay
 			

--- a/archey
+++ b/archey
@@ -212,7 +212,7 @@ class RAM:
 	def __init__(self):
 		raminfo = Popen(['free', '-m'], stdout=PIPE).communicate()[0].decode('Utf-8').split('\n')
 		ram = ''.join(filter(re.compile('M').search, raminfo)).split()
-		used = int(ram[2])
+		used = ram[2]
 		total = ram[1]
 		usedpercent = ((float(used) / float(total)) * 100)
 		if usedpercent <= 33:


### PR DESCRIPTION
The output of 'free -m' has changed again, resulting in a negative value for used ram.  This is just a quick fix to read the correct value.